### PR TITLE
Feature/enable npm link

### DIFF
--- a/bin/autokin-cli.js
+++ b/bin/autokin-cli.js
@@ -37,7 +37,7 @@ module.exports.default = function ({ specs, tags, formatter, junit, variables, t
     if (time) process.env.AUTOKIN_TIME = 'true';
     if (ci) process.env.AUTOKIN_CI = 'true';
 
-    let cli = new (require('cucumber').Cli)({ argv: cliOptions, cwd: process.cwd(), stdout: process.stdout });
+    let cli = new (require(`${process.cwd()}/node_modules/cucumber`).Cli)({ argv: cliOptions, cwd: process.cwd(), stdout: process.stdout });
     return new Promise(function (resolve, reject) {
         try {
             return cli.run()

--- a/bin/autokin-init.js
+++ b/bin/autokin-init.js
@@ -31,7 +31,7 @@ module.exports.default = function () {
 
     process.stdout.write('Creating steps...');
     let steps_template = '// Autokin Generated File - Do not delete.\n\n' + 
-                   'const { setDefaultTimeout } = require(\'cucumber\');\n' +
+                   'const { setDefaultTimeout } = require(process.cwd() + \'/node_modules/cucumber\');\n' +
                    'setDefaultTimeout(60 * 1000);\n'; 
     fs.writeFileSync(supportLocation + '/steps.js', steps_template);
     process.stdout.write('done.\n');

--- a/lib/autokin-options.js
+++ b/lib/autokin-options.js
@@ -1,2 +1,2 @@
-const { setDefaultTimeout } = require('cucumber');
+const { setDefaultTimeout } = require(`${process.cwd()}/node_modules/cucumber`);
 setDefaultTimeout(600 * 1000);

--- a/lib/autokin-rest-steps.js
+++ b/lib/autokin-rest-steps.js
@@ -6,7 +6,7 @@
  */
 "use strict";
 
-const { Before, Given, When, Then, defineParameterType } = require("cucumber");
+const { Before, Given, When, Then, defineParameterType } = require(`${process.cwd()}/node_modules/cucumber`);
 const { expect } = require("chai");
 const { RestBuilder, Utils, Store } = require("./autokin");
 const { parse } = require("node-html-parser");

--- a/lib/formatter/autokin-formatter.js
+++ b/lib/formatter/autokin-formatter.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-const { JsonFormatter } = require('cucumber');
+const { JsonFormatter } = require(`${process.cwd()}/node_modules/cucumber`);
 const Table = require('cli-table3');
 const colors = require('chalk');
 const readline = require('readline');

--- a/lib/mobile/autokin-mobile-steps.js
+++ b/lib/mobile/autokin-mobile-steps.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-const { Given, When, Then } = require('cucumber');
+const { Given, When, Then } = require(`${process.cwd()}/node_modules/cucumber`);
 const { expect } = require('chai');
 const { MobileBuilder } = require('./autokin-mobile');
 const { Store } = require('../autokin');

--- a/lib/web/autokin-playwright-steps.js
+++ b/lib/web/autokin-playwright-steps.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-const { Given, When, Then } = require('cucumber');
+const { Given, When, Then } = require(`${process.cwd()}/node_modules/cucumber`);
 const { expect } = require('chai');
 const { WebBuilder } = require('./autokin-web');
 const Store = require('../autokin-store');

--- a/lib/web/autokin-puppeteer-steps.js
+++ b/lib/web/autokin-puppeteer-steps.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-const { Given, When, Then } = require('cucumber');
+const { Given, When, Then } = require(`${process.cwd()}/node_modules/cucumber`);
 const { expect } = require('chai');
 const { WebBuilder } = require('./autokin-web');
 


### PR DESCRIPTION
In this PR, we enable the feature to able to run the autokin by npm/yarn link. We added the `process.cwd()` is to make sure autokin will always require expected the cucumber library, which is the cucumber library from the projects we added the test.

### The scenario we are trying to fix:
1. autokin cloned to local
2. Some project need to be tested was cloned to local
3. In that project, we
  a. `yarn link "autokin"`
  b. Added some test case
  c. Run test cases